### PR TITLE
update vivado ruleos to support ip to ip and xsim

### DIFF
--- a/vivado/README.md
+++ b/vivado/README.md
@@ -192,6 +192,20 @@ current_fileset
 open_wave_database bazel-out/k8-fastbuild/bin/vivado/tests/xsim_smoke_test.wdb
 ```
 
+To test a module that depends on ip blocks, the ip vlocks need to be added in `ip_blocks` field.
+```
+xsim_test(
+    name = "weights_replay_and_save_xsim",
+    ip_blocks = [
+        ":weights_replay_and_save_ip",
+    ],
+    module = ":weights_replay_and_save_tb",
+    module_top = "weights_replay_and_save_tb",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+```
 ## vivado_create_ip
 
 Creates and IP block from a module for vivado.
@@ -212,3 +226,22 @@ vivado_create_ip(
 ```
 
 This will generate an ip repository directory that can be included in vivado projects.
+
+If an ip block relies on other ip blocks, the `ip_blocks` field needs to be updated.
+```
+vivado_create_ip(
+    name = "weights_replay_and_save_ip",
+    ip_blocks = [
+        ":weights_replay_ip",
+        ":weights_ram_ip",
+    ],
+    ip_library = "test",
+    ip_vendor = "test_vendor",
+    ip_version = "0.1",
+    module = ":weights_replay_and_save_bd",
+    module_top = "weights_replay_and_save",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+```

--- a/vivado/create_ip_block.tcl.template
+++ b/vivado/create_ip_block.tcl.template
@@ -2,6 +2,8 @@ create_project project_1 {{PROJECT_DIR}} -part {{PART_NUMBER}}
 
 {{HDL_SOURCE_CONTENT}}
 
+{{IP_BLOCK_TCL}}
+
 {{TCL_CONTENT}}
 
 {{CONSTRAINTS_CONTENT}}

--- a/vivado/providers.bzl
+++ b/vivado/providers.bzl
@@ -25,5 +25,9 @@ VivadoIPBlockInfo = provider(
     doc = "Info for a vivado ip block",
     fields = {
         "repo": "Repo containing ip block.",
+        "vendor": "The vendor of the ip block.",
+        "library": "The library that the ip block belongs to.",
+        "version": "The ip block version.",
+        "module_top": "The name of the ip block top module.",
     },
 )

--- a/vivado/tests/BUILD
+++ b/vivado/tests/BUILD
@@ -111,6 +111,7 @@ verilator_cc_library(
     name = "weights_replay_verilator",
     module = ":weights_replay",
     module_top = "weights_replay",
+    vopts = ["-D__VERILATOR__"],
 )
 
 cc_test(
@@ -165,6 +166,87 @@ vivado_create_project(
     ],
     module = ":weights_replay_top",
     module_top = "weights_replay_top",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+
+verilog_library(
+    name = "weights_ram",
+    srcs = [
+        "weights_ram.sv",
+    ],
+)
+
+vivado_create_ip(
+    name = "weights_ram_ip",
+    encrypt = False,
+    ip_library = "test",
+    ip_vendor = "test_vendor",
+    ip_version = "0.1",
+    module = ":weights_ram",
+    module_top = "weights_ram",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+
+verilog_library(
+    name = "weights_replay_and_save_bd",
+    srcs = [
+        "weights_replay_and_save_bd.tcl",
+    ],
+)
+
+vivado_create_ip(
+    name = "weights_replay_and_save_ip",
+    ip_blocks = [
+        ":weights_replay_ip",
+        ":weights_ram_ip",
+    ],
+    ip_library = "test",
+    ip_vendor = "test_vendor",
+    ip_version = "0.1",
+    module = ":weights_replay_and_save_bd",
+    module_top = "weights_replay_and_save",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+
+verilog_library(
+    name = "weights_replay_and_save_tb",
+    srcs = [
+        "weights_replay_and_save_tb.sv",
+    ],
+)
+
+xsim_test(
+    name = "weights_replay_and_save_xsim",
+    ip_blocks = [
+        ":weights_replay_and_save_ip",
+    ],
+    module = ":weights_replay_and_save_tb",
+    module_top = "weights_replay_and_save_tb",
+    part_number = "xczu28dr-ffvg1517-2-e",
+    tags = ["manual"],
+    xilinx_env = ":xilinx_env.sh",
+)
+
+verilog_library(
+    name = "weights_replay_and_save_wrapper",
+    srcs = [
+        "weights_replay_and_save_wrapper.sv",
+    ],
+)
+
+vivado_create_project(
+    name = "weights_replay_and_save_project",
+    ip_blocks = [
+        ":weights_replay_and_save_ip",
+    ],
+    module = ":weights_replay_and_save_wrapper",
+    module_top = "weights_replay_and_save_wrapper",
     part_number = "xczu28dr-ffvg1517-2-e",
     tags = ["manual"],
     xilinx_env = ":xilinx_env.sh",

--- a/vivado/tests/weights_ram.sv
+++ b/vivado/tests/weights_ram.sv
@@ -1,25 +1,15 @@
-
-module weights_replay #(
+module weights_ram #(
+    parameter int RAM_DEPTH = 8,
     parameter int COUNTER_BITS = 3
 ) (
     input logic clk,
     input logic rst,
-    output logic [7:0] shift_reg
+    input logic [7:0] shift_reg
 );
 
   logic [COUNTER_BITS - 1:0] counter;
   logic [2:0] weights_address;
-  logic [7:0] weights [1][8];
-
-`ifdef __VERILATOR__
-  initial begin
-    $readmemh("./vivado/tests/test.mem", weights);
-  end
-`else
-  initial begin
-    $readmemh("./test.mem", weights);
-  end
-`endif
+  logic [7:0] weights[1][RAM_DEPTH];
 
   always @(posedge clk) begin
     if (rst) begin
@@ -34,7 +24,6 @@ module weights_replay #(
         counter <= counter + 1;
       end
     end
-    shift_reg <= weights[0][weights_address];
+    weights[0][weights_address] <= shift_reg;
   end
-
 endmodule

--- a/vivado/tests/weights_replay_and_save_bd.tcl
+++ b/vivado/tests/weights_replay_and_save_bd.tcl
@@ -1,0 +1,212 @@
+
+################################################################
+# This is a generated script based on design: weights_replay_and_save
+#
+# Though there are limitations about the generated script,
+# the main purpose of this utility is to make learning
+# IP Integrator Tcl commands easier.
+################################################################
+
+namespace eval _tcl {
+proc get_script_folder {} {
+   set script_path [file normalize [info script]]
+   set script_folder [file dirname $script_path]
+   return $script_folder
+}
+}
+variable script_folder
+set script_folder [_tcl::get_script_folder]
+
+################################################################
+# START
+################################################################
+
+# To test this script, run the following commands from Vivado Tcl console:
+# source weights_replay_and_save_script.tcl
+
+# If there is no project opened, this script will create a
+# project, but make sure you do not have an existing project
+# <./myproj/project_1.xpr> in the current working folder.
+
+set list_projs [get_projects -quiet]
+if { $list_projs eq "" } {
+   create_project project_1 myproj -part xczu28dr-ffvg1517-2-e
+}
+
+
+# CHANGE DESIGN NAME HERE
+variable design_name
+set design_name weights_replay_and_save
+
+# If you do not already have an existing IP Integrator design open,
+# you can create a design using the following command:
+#    create_bd_design $design_name
+
+# Creating design if needed
+set errMsg ""
+set nRet 0
+
+set cur_design [current_bd_design -quiet]
+set list_cells [get_bd_cells -quiet]
+
+if { ${design_name} eq "" } {
+   # USE CASES:
+   #    1) Design_name not set
+
+   set errMsg "Please set the variable <design_name> to a non-empty value."
+   set nRet 1
+
+} elseif { ${cur_design} ne "" && ${list_cells} eq "" } {
+   # USE CASES:
+   #    2): Current design opened AND is empty AND names same.
+   #    3): Current design opened AND is empty AND names diff; design_name NOT in project.
+   #    4): Current design opened AND is empty AND names diff; design_name exists in project.
+
+   if { $cur_design ne $design_name } {
+      common::send_gid_msg -ssname BD::TCL -id 2001 -severity "INFO" "Changing value of <design_name> from <$design_name> to <$cur_design> since current design is empty."
+      set design_name [get_property NAME $cur_design]
+   }
+   common::send_gid_msg -ssname BD::TCL -id 2002 -severity "INFO" "Constructing design in IPI design <$cur_design>..."
+
+} elseif { ${cur_design} ne "" && $list_cells ne "" && $cur_design eq $design_name } {
+   # USE CASES:
+   #    5) Current design opened AND has components AND same names.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 1
+} elseif { [get_files -quiet ${design_name}.bd] ne "" } {
+   # USE CASES: 
+   #    6) Current opened design, has components, but diff names, design_name exists in project.
+   #    7) No opened design, design_name exists in project.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 2
+
+} else {
+   # USE CASES:
+   #    8) No opened design, design_name not in project.
+   #    9) Current opened design, has components, but diff names, design_name not in project.
+
+   common::send_gid_msg -ssname BD::TCL -id 2003 -severity "INFO" "Currently there is no design <$design_name> in project, so creating one..."
+
+   create_bd_design $design_name
+
+   common::send_gid_msg -ssname BD::TCL -id 2004 -severity "INFO" "Making design <$design_name> as current_bd_design."
+   current_bd_design $design_name
+
+}
+
+common::send_gid_msg -ssname BD::TCL -id 2005 -severity "INFO" "Currently the variable <design_name> is equal to \"$design_name\"."
+
+if { $nRet != 0 } {
+   catch {common::send_gid_msg -ssname BD::TCL -id 2006 -severity "ERROR" $errMsg}
+   return $nRet
+}
+
+set bCheckIPsPassed 1
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\ 
+test_vendor:test:weights_ram:0.1\
+test_vendor:test:weights_replay:0.1\
+"
+
+   set list_ips_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+   if { $list_ips_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2012 -severity "ERROR" "The following IPs are not found in the IP Catalog:\n  $list_ips_missing\n\nResolution: Please add the repository containing the IP(s) to the project." }
+      set bCheckIPsPassed 0
+   }
+
+}
+
+if { $bCheckIPsPassed != 1 } {
+  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
+  return 3
+}
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+
+  # Create ports
+  set clk [ create_bd_port -dir I clk ]
+  set rst [ create_bd_port -dir I rst ]
+
+  # Create instance: weights_ram_0, and set properties
+  set weights_ram_0 [ create_bd_cell -type ip -vlnv test_vendor:test:weights_ram:0.1 weights_ram_0 ]
+
+  # Create instance: weights_replay_0, and set properties
+  set weights_replay_0 [ create_bd_cell -type ip -vlnv test_vendor:test:weights_replay:0.1 weights_replay_0 ]
+
+  # Create port connections
+  connect_bd_net -net Net [get_bd_ports rst] [get_bd_pins weights_ram_0/rst] [get_bd_pins weights_replay_0/rst]
+  connect_bd_net -net Net1 [get_bd_ports clk] [get_bd_pins weights_ram_0/clk] [get_bd_pins weights_replay_0/clk]
+  connect_bd_net -net weights_replay_0_shift_reg [get_bd_pins weights_ram_0/shift_reg] [get_bd_pins weights_replay_0/shift_reg]
+
+  # Create address segments
+
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  validate_bd_design
+  save_bd_design
+}
+# End of create_root_design()
+
+
+##################################################################
+# MAIN FLOW
+##################################################################
+
+create_root_design ""
+
+

--- a/vivado/tests/weights_replay_and_save_tb.sv
+++ b/vivado/tests/weights_replay_and_save_tb.sv
@@ -1,0 +1,34 @@
+/*
+    This testbench tests if the IP blocks inside of IP blocks are properly imported.
+*/
+module weights_replay_and_save_tb;
+
+  logic clk = 0;
+  logic rst = 0;
+  realtime ClkPeriod = 100;
+
+  always #(ClkPeriod / 2) clk = ~clk;
+  weights_replay_and_save_ip weights_replay_and_save_dut (
+      .clk(clk),
+      .rst(rst)
+  );
+  initial begin
+    rst = 1;
+    repeat (100) begin
+      @(posedge clk);
+    end
+    rst = 0;
+    repeat (100) begin
+      @(posedge clk);
+    end
+    for (int i = 0; i < 8; i++) begin
+      if(weights_replay_and_save_dut.inst.weights_ram_0.inst.weights[0][i]
+      !==weights_replay_and_save_dut.inst.weights_replay_0.inst.weights[0][i]) begin
+        $error("RAM value mismatched on index %d!",i);
+        $finish;
+      end
+    end
+    $display("Test passed!");
+    $finish;
+  end
+endmodule

--- a/vivado/tests/weights_replay_and_save_wrapper.sv
+++ b/vivado/tests/weights_replay_and_save_wrapper.sv
@@ -1,0 +1,6 @@
+module weights_replay_and_save_wrapper;
+  weights_replay_and_save_ip weights_replay_and_save_ip (
+      .clk(clk),
+      .rst(rst)
+  );
+endmodule

--- a/vivado/xsim_test.tcl.template
+++ b/vivado/xsim_test.tcl.template
@@ -2,6 +2,8 @@ create_project project_1 {{PROJECT_DIR}} -part {{PART_NUMBER}}
 
 {{HDL_SOURCE_CONTENT}}
 
+{{IP_BLOCK_TCL}}
+
 {{TCL_CONTENT}}
 
 {{CONSTRAINTS_CONTENT}}


### PR DESCRIPTION
The current `xsim_test` and `vivado_create_ip` cannot support ip blocks as arguments, In certain use cases, users may want to add custom ip blocks into their ip bblocks, and test the ip blocks using xsim. 
This PR adds support for ip blocks to the `xsim_test` and `vivado_create_ip` rules, supporting multiple ip blocks to an ip block.
